### PR TITLE
Fixing system prompt being ignored in long chats

### DIFF
--- a/src/Client/Copilot/CopilotChat.cs
+++ b/src/Client/Copilot/CopilotChat.cs
@@ -294,6 +294,7 @@ public class CopilotChat : ICopilotChat
             relevant: relevant,
             application: application.Id,
             temporal: temporalRangeGrounding,
+            messages: conversation.Messages,
             model: Model.Id
         );
 


### PR DESCRIPTION
This change ensures that all the conversation messages are being sent to the `QGPTInput`.

This fixes an issue where the system prompt is ignored after a few messages.